### PR TITLE
Consider URL-encoding when comparing google photos filename

### DIFF
--- a/main.go
+++ b/main.go
@@ -2305,6 +2305,11 @@ func absInt(x int) int {
 // Compare two file names, where s2 is sometimes mangled by gphotos
 // there will be some false positives, this is ok
 func compareMangled(s1, s2 string) bool {
+	// URL-decoding s1 since Google Photos may return URL-encoded filenames
+	if decoded, err := url.QueryUnescape(s1); err == nil {
+		s1 = decoded
+	}
+	
 	sr1 := []rune(s1)
 	sr2 := []rune(s2)
 


### PR DESCRIPTION
Fixes https://github.com/spraot/gphotos-sync/issues/21


    {
        "level": "error",
        "workerid": 1,
        "itemid": "af1qipn6guag-ychga_cheycjh31vsmqf1j7dpc8hlol",
        "batchitemindex": 0,
        "isoriginal": false,
        "error": "expected file img_20141114_125316%253anopm%253a.jpg but downloaded file img_20141114_125316%3anopm%3a.jpg for af1qipn6guag-ychga_cheycjh31vsmqf1j7dpc8hlol (unexpected download)",
        "dt": "2025-09-20t16:04:54.587z",
        "message": "error processing download for af1qipn6guag-ychga_cheycjh31vsmqf1j7dpc8hlol (try 1/3)"
    }