### PR TITLE
add option to list albums

### DIFF
--- a/main.go
+++ b/main.go
@@ -1409,10 +1409,10 @@ func albumIdFromUrl(location string) (string, error) {
 	// Split the path into segments
 	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
 
-	// Look for "photo" segment and ensure there's a following segment
+	// Look for "album" segment and ensure there's a following segment
 	for i := 0; i < len(parts)-1; i++ {
-		if parts[i] == "album" || parts[i] == "share" {
-			return parts[i+1], nil
+		if parts[i] == "album" || parts[i] == "share" || parts[i] == *albumTypeFlag {
+			return parts[i] + "/" + parts[i+1], nil
 		}
 	}
 	return "", fmt.Errorf("could not find /share|album/{albumId} pattern in URL: %v", location)

--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ var (
 	workersFlag     = flag.Int64("workers", 1, "number of concurrent downloads allowed")
 	albumIdFlag     = flag.String("album", "", "ID of album to download, has no effect if lastdone file is found or if -start contains full URL")
 	albumTypeFlag   = flag.String("albumtype", "album", "type of album to download (as seen in URL), has no effect if lastdone file is found or if -start contains full URL")
+	listAlbumsFlag  = flag.Bool("listalbums", false, "find album IDs, don't download anything")
 	batchSizeFlag   = flag.Int("batchsize", 0, "number of photos to download in one batch")
 	execPathFlag    = flag.String("execpath", "", "path to Chrome/Chromium binary to use")
 )
@@ -187,6 +188,11 @@ func main() {
 	} else {
 		log.Info().Msgf("using locale %s", locale)
 		loc = _loc
+	}
+
+	if *listAlbumsFlag {
+		listAlbums(s, startupCtx, ctx, startupCancel)
+		return
 	}
 
 	if err := chromedp.Run(startupCtx,
@@ -596,6 +602,107 @@ func captureScreenshot(ctx context.Context, filePath string) {
 	} else if err := os.WriteFile(filePath+".html", []byte(html), 0640); err != nil {
 		log.Err(err).Msgf("failed to write HTML: %v", err)
 	}
+}
+
+// print out all album IDs
+func listAlbums(s *Session, startupCtx context.Context, ctx context.Context, startupCancel context.CancelFunc) {
+	if err := chromedp.Run(startupCtx,
+		chromedp.ActionFunc(s.navigateToAlbums),
+	); err != nil {
+		log.Fatal().Msgf("failed to load albums page: %v", err)
+	}
+	startupCancel()
+
+	if err := chromedp.Run(ctx,
+		chromedp.ActionFunc(func(ctx context.Context) (err error) {
+			log.Info().Msgf("Identified albums...")
+			for {
+				albumId, err := s.findNextAlbum(ctx)
+				if err != nil {
+					return err
+				}
+				if albumId == "" {
+					break
+				}
+				log.Info().Msgf("albumId: %s", albumId)
+			}
+			log.Info().Msg("Done")
+			return nil
+		}),
+	); err != nil {
+		log.Fatal().Msgf("failed to list albums: %v", err)
+	}
+}
+
+// loads the albums page and leaves it with nothing selected
+func (s *Session) navigateToAlbums(ctx context.Context) (err error) {
+	if err := s.navigateWithAction(ctx, log.Logger, chromedp.Navigate(gphotosUrl+"/albums"), "to albums", 20000*time.Millisecond, 5); err != nil {
+		return err
+	}
+	chromedp.WaitReady("body", chromedp.ByQuery).Do(ctx)
+
+	// This is only used to ensure page is loaded
+	_, err = s.findNextAlbum(ctx)
+	if err != nil {
+		return err
+	}
+
+	var location string
+	if err := chromedp.Run(ctx,
+		chromedp.Evaluate("document.activeElement.blur()", nil),
+		chromedp.Location(&location),
+	); err != nil {
+		return err
+	}
+	log.Debug().Msgf("location: %v", location)
+
+	return nil
+}
+
+func (s *Session) findNextAlbum(ctx context.Context) (string, error) {
+	// wait for page to be loaded, i.e. that we can make an element active by using
+	// the right arrow key, or if an element was already selected, go to the next album
+	var firstItem string
+	attributes := make(map[string]string)
+
+	if err := chromedp.Run(ctx, chromedp.Attributes(`document.activeElement`, &attributes, chromedp.ByJSPath)); err == nil {
+		itemHref, ok := attributes["href"]
+		if ok {
+			firstItem = itemHref
+		}
+	}
+
+	for {
+		log.Trace().Msg("attempting to find next album")
+		if err := chromedp.Run(ctx,
+			chromedp.KeyEvent(kb.ArrowRight),
+			chromedp.Sleep(tick),
+			chromedp.Attributes(`document.activeElement`, &attributes, chromedp.ByJSPath)); err != nil {
+			return "", err
+		}
+		if len(attributes) == 0 {
+			time.Sleep(tick)
+			continue
+		}
+
+		itemHref, ok := attributes["href"]
+		if ok {
+			if itemHref == firstItem {
+				break
+			}
+
+			res, err := albumIdFromUrl(itemHref)
+			if err == nil {
+				log.Debug().Msgf("page loaded, next album in the feed is: %s", res)
+				return res, nil
+			}
+		} else {
+			break
+		}
+	}
+
+	log.Warn().Msgf("page loaded, could not find any album")
+	return "", nil
 }
 
 // firstNav does either of:
@@ -1290,6 +1397,25 @@ func imageIdFromUrl(location string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("could not find /photo/{imageId} pattern in URL: %v", location)
+}
+
+func albumIdFromUrl(location string) (string, error) {
+	// Parse the URL
+	u, err := url.Parse(location)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL %v: %w", location, err)
+	}
+
+	// Split the path into segments
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+
+	// Look for "photo" segment and ensure there's a following segment
+	for i := 0; i < len(parts)-1; i++ {
+		if parts[i] == "album" || parts[i] == "share" {
+			return parts[i+1], nil
+		}
+	}
+	return "", fmt.Errorf("could not find /share|album/{albumId} pattern in URL: %v", location)
 }
 
 // makeOutDir creates a directory in s.downloadDir named of the item ID


### PR DESCRIPTION
gphotos-cdp has the ability to download a specific album by ID, but no way to get a list of available albums; this PR adds a command line flag to utilize gphotos-cdp's existing photos.google.com access infrastructure to step through the albums page instead of the photos page, with the goal of enabling scripts to pull all albums individually