### PR TITLE
resync: fall back to imageId when lastNode is virtualized away

### DIFF
--- a/main.go
+++ b/main.go
@@ -1679,6 +1679,7 @@ func (s *Session) resync(ctx context.Context) error {
 	listenNavEvents(ctx)
 
 	lastNode := &cdp.Node{}
+	lastImageId := "" // stable identity for lastNode — survives Google's virtualized list unmount/remount
 	var nodes []*cdp.Node
 	i := 0                         // next node to process in nodes array
 	n := 0                         // number of nodes processed in all
@@ -1854,12 +1855,33 @@ syncAllLoop:
 			}
 			log.Trace().Msgf("found %d items, checking if any are new", len(nodes))
 
-			// remove already processed nodes
+			// Slice off already-processed nodes. Prefer pointer equality
+			// (fast, works in steady-state via chromedp's frame-tree
+			// node interning), then fall back to matching by imageId.
+			// The imageId fallback catches the case where Google's
+			// virtualized list has unmounted the previous lastNode
+			// between this query and the last one, leaving its *cdp.Node
+			// pointer dangling and absent from the new results — pointer
+			// equality silently fails and the dedupe was a no-op, which
+			// could let us re-process old items or skip past unread ones.
 			foundNodes := len(nodes)
+			sliced := false
 			for i, node := range nodes {
 				if node == lastNode {
 					nodes = nodes[i+1:]
+					sliced = true
 					break
+				}
+			}
+			if !sliced && lastImageId != "" {
+				for i, node := range nodes {
+					id, idErr := imageIdFromUrl(node.AttributeValue("href"))
+					if idErr == nil && id == lastImageId {
+						log.Debug().Msgf("scroll anchor recovered by imageId %s after stale NodeID %v", lastImageId, lastNode.NodeID)
+						nodes = nodes[i+1:]
+						sliced = true
+						break
+					}
 				}
 			}
 			if len(nodes) == 0 {
@@ -1867,8 +1889,8 @@ syncAllLoop:
 				continue
 			}
 			log.Trace().Msgf("%d nodes on page, processing %d that haven't been processed yet", foundNodes, len(nodes))
-			if foundNodes == len(nodes) {
-				log.Warn().Msg("only new nodes found, expected an overlap")
+			if !sliced && foundNodes == len(nodes) {
+				log.Warn().Msg("scroll anchor not found by NodeID or imageId — processing full query (isNewItem will filter duplicates)")
 			}
 
 			retries = 0
@@ -1887,6 +1909,7 @@ syncAllLoop:
 			if err != nil {
 				return fmt.Errorf("error getting item id from url, %w", err)
 			}
+			lastImageId = imageId // track for dedupe fallback if the *cdp.Node ptr later goes stale
 
 			if strings.EqualFold(imageId, *untilFlag) {
 				foundUntil = true


### PR DESCRIPTION
## Summary

The scroll-anchor dedupe in `resync` relies on pointer equality between `lastNode` (saved from the previous `chromedp.Nodes` call) and entries in the next query:

```go
for i, node := range nodes {
    if node == lastNode {
        nodes = nodes[i+1:]
        break
    }
}
```

This works because chromedp interns `*cdp.Node` pointers via its frame node tree — same NodeID returns the same pointer. **But:** when Google Photos' virtualized list unmounts the anchor between queries, the new query returns fresh pointers that don't include the previous `lastNode` at all. The for-loop finishes without matching, `nodes` stays unsliced, and either:

- the "only new nodes found, expected an overlap" warning fires and we process the full slice (relying on `isNewItem` to filter duplicates — but `n` still increments on every item, including re-processed ones, which can mask actual stall in the watchdog), or
- the query happens to be tail-aligned, and we should have sliced to empty (triggering `retries++; continue`) but instead re-process items, masking a genuine "scroll didn't load more" signal.

## Change

Track `lastImageId` alongside `lastNode`. `imageId` is the photo's stable permalink suffix and survives virtualized unmount/remount. After pointer equality fails to find the anchor, try matching by `imageId` against each node's `href` attribute.

```go
if !sliced && lastImageId != "" {
    for i, node := range nodes {
        id, idErr := imageIdFromUrl(node.AttributeValue("href"))
        if idErr == nil && id == lastImageId {
            log.Debug().Msgf("scroll anchor recovered by imageId %s after stale NodeID %v", lastImageId, lastNode.NodeID)
            nodes = nodes[i+1:]
            sliced = true
            break
        }
    }
}
```

Also: the "no overlap" warning now fires only when *neither* match worked (so steady-state runs stay quiet), and the message is reworded to describe the actual situation (anchor lost entirely → process full query, `isNewItem` filters).

## Cost

- Steady-state: no change. Pointer match hits on first pass; the imageId loop is skipped.
- Fallback hot path: one extra O(n) scan + one `imageIdFromUrl` call per node, bounded by the page's visible-node count (a few hundred at most).
- Memory: one extra `string` per resync invocation.

## Test plan

- [x] `go build .` — passes
- [x] `go vet ./...` — clean
- [ ] End-to-end: run a catch-up against a real account through a virtualization-heavy window (~20+ visible items scrolled through quickly); verify the debug log `"scroll anchor recovered by imageId..."` appears at least once and that no items are skipped between consecutive `.lastdone` checkpoints.

## Companion PRs

- [spraot/gphotos-cdp#10](https://github.com/spraot/gphotos-cdp/pull/10) — replaces the deadman `panic()` with a clean error+cancel, and watches `downloadedCount` so the deadman doesn't fire while downloads are draining.
- [spraot/gphotos-sync#32](https://github.com/spraot/gphotos-sync/pull/32) — wraps the cdp call in retry-with-backoff in `sync.sh`.

Each PR is useful in isolation; together they make the failure mode self-healing without operator intervention.