### PR TITLE
backup-method: bound chromedp.Run calls so a non-ACKing Chrome doesn't hang the worker

### DIFF
--- a/main.go
+++ b/main.go
@@ -883,7 +883,21 @@ func requestDownloadBackup(ctx context.Context, log zerolog.Logger) error {
 	start := time.Now()
 
 	log.Debug().Msgf("requesting download (backup method)")
-	target.ActivateTarget(chromedp.FromContext(ctx).Target.TargetID).Do(ctx)
+
+	// Bound the DevTools-protocol call below — it's synchronous and
+	// inherits the worker's ctx, which has no deadline. If Chrome stops
+	// ACKing target activations (observed on certain poisoned items in
+	// the wild), an unbounded chromedp.Run will hang here forever,
+	// holding the tab lock + blocking startDownload's outer 120s
+	// timeoutTimer from ever running. Cap at 5s so the error bubbles up
+	// to startDownload's retry path.
+	activateCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	err := target.ActivateTarget(chromedp.FromContext(activateCtx).Target.TargetID).Do(activateCtx)
+	cancel()
+	if err != nil {
+		return fmt.Errorf("activating target for backup download: %w", err)
+	}
+
 	if err := pressButton(ctx, "D", input.ModifierShift); err != nil {
 		return err
 	}
@@ -915,8 +929,15 @@ func pressButton(ctx context.Context, key string, modifier input.Modifier) error
 	for _, ev := range []*input.DispatchKeyEventParams{&down, &up} {
 		log.Trace().Msgf("triggering button press event: %v, %v, %v", ev.Key, ev.Type, ev.Modifiers)
 
-		if err := chromedp.Run(ctx, ev); err != nil {
-			return err
+		// Each keystroke event is an unbounded DevTools-protocol call.
+		// Bound it so a non-ACKing Chrome surfaces as an error within
+		// 5s instead of hanging the caller — see requestDownloadBackup
+		// for the wedge this prevents.
+		pressCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		err := chromedp.Run(pressCtx, ev)
+		cancel()
+		if err != nil {
+			return fmt.Errorf("dispatching key event %v %v: %w", ev.Key, ev.Type, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

`requestDownloadBackup` and `pressButton` issue chromedp.Run calls with the worker's outer `ctx`, which has no deadline. When Chrome stops ACKing DevTools-protocol messages (consistently observed on certain poisoned items that fall through `requestDownload`'s primary path to the backup), these calls hang **indefinitely** — the worker holds the tab lock, `startDownload`'s outer `for { select }` never re-enters to check its 120s `timeoutTimer`, and through the unbuffered `jobChan` the main `syncAllLoop` ends up blocked too.

Net effect today: a single poisoned item stalls the entire sync. No fatal fires. The progress logger keeps ticking enumeration but downloads sit at 0 and the queue stays frozen.

## Change

Wrap each `chromedp.Run` call in `requestDownloadBackup` and `pressButton` with a 5s `context.WithTimeout`. On a non-ACKing Chrome:
- `requestDownloadBackup`'s `target.ActivateTarget(...).Do(ctx)` returns within 5s
- `pressButton`'s per-event `chromedp.Run(ctx, ev)` returns within 5s

The error bubbles up to `startDownload`, which exits the inner attempt, returns to its select loop, and the existing 120s `timeoutTimer` + `refreshTimer` retry logic finally gets a chance to run.

## Observed failure mode this addresses

```
worker 1: "tried to request download 3 times, giving up now"
worker 1: "acquired tab lock to request download (backup method)"
worker 1: "requesting download (backup method)"
[no further logs from this worker]
[5+ minutes of "so far: downloaded 0 (1 in queue)" with enumeration continuing]
```

Reproduces deterministically on item `AF1QipNimAHU…` in our environment.

## Cost

- Steady-state: no behavioral change. Successful chromedp.Run completes in low-ms; 5s ceiling never trips.
- Failure path: now errors-out in 5s per call instead of hanging forever. Net positive for retry/recovery.

## Test plan

- [x] `go build .` — passes
- [x] `go vet ./...` — clean
- [ ] End-to-end against an account with a known wedge-prone item; verify the worker logs the wrapped error within 5s of entering `requestDownloadBackup` instead of going silent, and `startDownload`'s 120s timeout eventually fires.