### PR TITLE
videoStillProcessing: bound chromedp.Run + bubble as errCouldNotLoadPhoto

### DIFF
--- a/main.go
+++ b/main.go
@@ -1123,9 +1123,22 @@ func (s *Session) getPhotoData(ctx context.Context, log zerolog.Logger, imageId 
 
 			target.ActivateTarget(chromedp.FromContext(ctx).Target.TargetID).Do(ctx)
 
-			// If video is 'still processing', photo data may never load, so stop here
+			// If video is 'still processing', photo data may never load, so stop here.
+			// Bound this chromedp.Run with a short timeout (#12-style): the outer
+			// getPhotoData ctx has 4 minutes, but when Google's SPA hangs on this
+			// specific photo the chromedp.Run can sit on the unbounded inner call
+			// for the full 4 minutes before bubbling up, holding the tab lock the
+			// whole time and starving every other worker. Cap at 5s; on timeout,
+			// wrap as errCouldNotLoadPhoto so the worker skip-and-continue path
+			// (introduced in e9e7908) handles it rather than failing the run.
 			var undownloadable bool
-			if err := chromedp.Run(ctx, chromedp.Evaluate(`[...document.querySelectorAll('c-wiz[data-media-key*="'+document.location.href.trim().split('/').pop()+'"]')].filter(x => getComputedStyle(x).visibility != 'hidden')[0]?.textContent.indexOf('Your video will be ready soon') >= 0`, &undownloadable)); err != nil {
+			videoCheckCtx, videoCheckCancel := context.WithTimeout(ctx, 5*time.Second)
+			err := chromedp.Run(videoCheckCtx, chromedp.Evaluate(`[...document.querySelectorAll('c-wiz[data-media-key*="'+document.location.href.trim().split('/').pop()+'"]')].filter(x => getComputedStyle(x).visibility != 'hidden')[0]?.textContent.indexOf('Your video will be ready soon') >= 0`, &undownloadable))
+			videoCheckCancel()
+			if err != nil {
+				if errors.Is(err, context.DeadlineExceeded) {
+					return fmt.Errorf("%w: videoStillProcessing check timed out: %w", errCouldNotLoadPhoto, err)
+				}
 				return fmt.Errorf("while checking if video is still processing %w", err)
 			}
 			if undownloadable {


### PR DESCRIPTION
## Summary

Same shape as [#12](https://github.com/spraot/gphotos-cdp/pull/12) (backup-method / pressButton), in a different code path.

`getPhotoData` calls `chromedp.Run` to check Google's "Your video will be ready soon" banner. The Run uses the outer ctx (`context.WithTimeout(ctx, 4*time.Minute)`). When Google's SPA hangs on a specific photo (deterministic per-photo Google bug), this call sits unbounded for the full 4 minutes — the worker holds the tab lock the whole time and starves the others. e9e7908's 45s fast-fail check never gets a chance to fire because we're not in the iteration loop: we're inside the inner `chromedp.Run`.

## Change

Cap the call at 5s via `context.WithTimeout`. On timeout, wrap as `errCouldNotLoadPhoto` so the existing worker skip-and-continue path (also from e9e7908) handles it cleanly rather than failing the whole run.

```go
videoCheckCtx, videoCheckCancel := context.WithTimeout(ctx, 5*time.Second)
err := chromedp.Run(videoCheckCtx, chromedp.Evaluate(...))
videoCheckCancel()
if err != nil {
    if errors.Is(err, context.DeadlineExceeded) {
        return fmt.Errorf("%w: videoStillProcessing check timed out: %w", errCouldNotLoadPhoto, err)
    }
    return fmt.Errorf("while checking if video is still processing %w", err)
}
```

## Repro

Item `AF1QipNr5ZF2-INrmLd8G0eudqlHRwYuBRggFDv4vcWD` deterministically. Caught by the `-verify` audit at 2026-05-25:

```
AF1QipNr5ZF2-INrmLd8G0eudqlHRwYuBRggFDv4vcWD,remote_load_failed,"while checking if video is still processing context deadline exceeded",IMG_2567.jpg,,
```

Verify burned ~4 minutes on this single item before getting the result. Post-PR it should fail in 5s with `errCouldNotLoadPhoto`.

## Test plan

- [x] `go build .` — passes
- [x] `go vet ./...` — clean
- [ ] Re-run verify on the same item; expect status `remote_load_failed` again but with a fast-fail error message containing `errCouldNotLoadPhoto`/"timed out" and elapsed ~5s instead of ~4min
- [ ] Confirm live sync against the same item now skips cleanly (`skipping photo whose page failed to load` log line) instead of hanging the worker
