### PR TITLE
getPhotoData: narrow acquireTabLock to just the ActivateTarget call

### DIFF
--- a/main.go
+++ b/main.go
@@ -1117,11 +1117,23 @@ func (s *Session) getPhotoData(ctx context.Context, log zerolog.Logger, imageId 
 		start := time.Now()
 		log := log.With().Int("attempt", n).Logger()
 		if err := func() error {
-			unlock := acquireTabLock(log, "to extract photo data")
-			defer unlock()
 			log.Trace().Msgf("extracting photo data")
 
-			target.ActivateTarget(chromedp.FromContext(ctx).Target.TargetID).Do(ctx)
+			// Narrowed (was: lock held for the entire iteration). The
+			// global muTabActivity only needs to guard tab-foreground
+			// transitions — chromedp.Evaluate uses the per-target CDP
+			// session and doesn't depend on the foreground tab; nor do
+			// JS-triggered clicks via EvaluateAsDevTools. Keyboard /
+			// mouse events that DO need foreground use their own per-
+			// context muKbEvents lock (see checkForStillProcessing).
+			// Holding the lock for the full iteration serialized N
+			// verify workers to ~1× throughput; narrowing it lets the
+			// reads run in parallel.
+			func() {
+				unlock := acquireTabLock(log, "to activate tab for photo data")
+				defer unlock()
+				target.ActivateTarget(chromedp.FromContext(ctx).Target.TargetID).Do(ctx)
+			}()
 
 			// If video is 'still processing', photo data may never load, so stop here.
 			// Bound this chromedp.Run with a short timeout (#12-style): the outer


### PR DESCRIPTION
## Summary

The outer `muTabActivity` (acquireTabLock) was held for the *entire* iteration of `getPhotoData`'s extraction loop — including the chromedp.Evaluate reads of filename/date/time/timezone and any subsequent JS-triggered click. With the recent verify mode running N parallel workers ([#14](https://github.com/spraot/gphotos-cdp/pull/14)), every worker serialized through this one global lock — measured 7.8 items/min with `-workers 4` vs ~30/min with `-workers 1` on the same profile.

The lock only needs to guard `target.ActivateTarget` — tab-foreground transitions. chromedp.Evaluate uses the per-target CDP session and doesn't depend on foreground state; JS-triggered `.click()` via EvaluateAsDevTools doesn't either. Real keyboard / mouse events that *do* need foreground already use a separate per-context lock (`GetContextData(ctx).muKbEvents` around `chromedp.MouseClickNode`, see `checkForStillProcessing`).

## Change

Narrow `getPhotoData`'s outer `acquireTabLock` to wrap only the ActivateTarget call. The remainder of the iteration (videoStillProcessing check, four Evaluates for filename/date/time/tz, optional info-button click) runs without the global mutex.

## Why sync mode is safe

Sync mode workers all go through `getPhotoData` too. With the narrower lock:
- ActivateTarget still serializes across workers — Chrome's foreground tab semantics unchanged
- The reads after ActivateTarget don't care about foreground (they're per-target Evaluates)
- Keyboard input paths (pressButton in requestDownload/Backup) acquire `muTabActivity` themselves for their own ActivateTarget+keystroke sequences — independent of this change
- The `muKbEvents` per-context lock continues to serialize per-tab keyboard events

I.e., this is purely scope-reduction; no behavior change for the sync path.

## Test plan

- [x] `go build .` — passes
- [x] `go vet ./...` — clean
- [ ] verify with `-workers 4` on a real run: throughput should rise from ~7.8 items/min toward N× the single-worker baseline (target ~60-120 items/min depending on Google response time)
- [ ] sync mode end-to-end against a real account: confirm no new race or interleaving issues
